### PR TITLE
Make global rate limiter per-message and add tests

### DIFF
--- a/redis/consumer.go
+++ b/redis/consumer.go
@@ -283,13 +283,6 @@ func (c *redisConsumer) workerLoop(ctx context.Context, consumeFunction messagin
 			return
 		default:
 
-			// If global rate limiter is set then call it
-			if GlobalRateLimiter != nil {
-				if err := GlobalRateLimiter(false, c.config.Name); err != nil {
-					c.logger.Warn("global rate limiter failed", zap.String("error", err.Error()))
-				}
-			}
-
 			jobKeyPrefix := c.getJobKeyPrefix()
 			result, err := c.redisClient.Eval(ctx, fetchBatchLua, []string{runnableKey, visibilityKey}, batchSize, visibilityTimeout, jobKeyPrefix).Result()
 
@@ -319,6 +312,13 @@ func (c *redisConsumer) workerLoop(ctx context.Context, consumeFunction messagin
 					// Job payload missing (likely expired), clean up ZSet
 					c.redisClient.ZRem(ctx, visibilityKey, jobId)
 					continue
+				}
+
+				// If global rate limiter is set then call it
+				if GlobalRateLimiter != nil {
+					if err := GlobalRateLimiter(false, c.config.Name); err != nil {
+						c.logger.Warn("global rate limiter failed", zap.String("error", err.Error()))
+					}
 				}
 
 				if c.ratelimit != nil {

--- a/redis/consumer_prio.go
+++ b/redis/consumer_prio.go
@@ -221,13 +221,6 @@ func (c *redisPriorityConsumer) workerLoop(ctx context.Context, consumeFunction 
 			return
 		default:
 
-			// If global rate limiter is set then call it
-			if GlobalRateLimiter != nil {
-				if err := GlobalRateLimiter(false, c.config.Name); err != nil {
-					c.logger.Warn("global rate limiter failed", zap.String("error", err.Error()))
-				}
-			}
-
 			jobKeyPrefix := c.getJobKeyPrefix()
 			// Use fetchBatchPrioLua instead of fetchBatchLua
 			result, err := c.redisClient.Eval(ctx, fetchBatchPrioLua, []string{runnableKey, visibilityKey}, batchSize, visibilityTimeout, jobKeyPrefix).Result()
@@ -258,6 +251,13 @@ func (c *redisPriorityConsumer) workerLoop(ctx context.Context, consumeFunction 
 					c.redisClient.ZRem(ctx, visibilityKey, jobId)
 					c.logger.Warn("TTL reached for redis (ignore job)", zap.String("jobKeyPrefix", jobKeyPrefix), zap.String("jobKeyPrefix", jobKeyPrefix), zap.String("job_id", jobId))
 					continue
+				}
+
+				// If global rate limiter is set then call it
+				if GlobalRateLimiter != nil {
+					if err := GlobalRateLimiter(false, c.config.Name); err != nil {
+						c.logger.Warn("global rate limiter failed", zap.String("error", err.Error()))
+					}
 				}
 
 				if c.ratelimit != nil {

--- a/redis/ratelimiter_test.go
+++ b/redis/ratelimiter_test.go
@@ -1,0 +1,176 @@
+package redis
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/devlibx/gox-base/v2/test"
+	"github.com/devlibx/gox-base/v2/util"
+	messaging "github.com/devlibx/gox-messaging/v2"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+// TestRedisConsumerGlobalRateLimiterPerMessage verifies that the global rate
+// limiter hook is invoked exactly once per successfully consumed message (not
+// once per batch fetch). This pins the per-message contract: the hook lives
+// inside the inner message loop, next to c.ratelimit.Take().
+func TestRedisConsumerGlobalRateLimiterPerMessage(t *testing.T) {
+	if util.IsStringEmpty(redisEndpoint) {
+		redisEndpoint = "localhost:6379"
+	}
+
+	cf, _ := test.MockCf(t, zap.InfoLevel)
+	topic := fmt.Sprintf("test-grl-%d", time.Now().UnixNano())
+	serviceName := "test-" + uuid.NewString()
+	consumerName := "grl-cons"
+
+	producer, err := NewRedisProducer(cf, messaging.ProducerConfig{
+		Name: "p", Type: "redis", Topic: topic, Enabled: true,
+		Endpoint: redisEndpoint, MandatoryServiceName: serviceName,
+	})
+	if err != nil {
+		t.Skip("Redis not available")
+		return
+	}
+
+	consumer, err := NewRedisConsumer(cf, messaging.ConsumerConfig{
+		Name: consumerName, Type: "redis", Topic: topic, Enabled: true,
+		Endpoint: redisEndpoint, MandatoryServiceName: serviceName,
+		// Large batch on purpose: if the hook were called per-fetch instead of
+		// per-message, one fetch would grab all messages and the count would be
+		// far less than the number of messages sent.
+		Properties: map[string]interface{}{"batch_size": 100},
+	})
+	assert.NoError(t, err)
+
+	// Override the global rate limiter with a per-consumer-name counter.
+	var grlCalls int64
+	var sawProducerFlag int32 // 1 if we ever saw producerOrConsumer==true
+	originalGRL := GlobalRateLimiter
+	GlobalRateLimiter = func(producerOrConsumer bool, name string) error {
+		if name != consumerName {
+			return nil // ignore any unrelated consumers
+		}
+		if producerOrConsumer {
+			atomic.StoreInt32(&sawProducerFlag, 1)
+		}
+		atomic.AddInt64(&grlCalls, 1)
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Teardown in a fixed order so the worker goroutine has stopped reading the
+	// package-level GlobalRateLimiter var before we restore it (Stop() does not
+	// wait for workerLoop to exit).
+	defer func() {
+		cancel()
+		_ = consumer.Stop()
+		_ = producer.Stop()
+		time.Sleep(300 * time.Millisecond)
+		GlobalRateLimiter = originalGRL
+	}()
+
+	var processedCount int64
+	consumeFunc := &mockConsumeFunction{
+		processFunc: func(message *messaging.Message) error {
+			atomic.AddInt64(&processedCount, 1)
+			return nil
+		},
+	}
+
+	err = consumer.Process(ctx, consumeFunc)
+	assert.NoError(t, err)
+
+	const n = 5
+	for i := 0; i < n; i++ {
+		<-producer.Send(ctx, &messaging.Message{Key: fmt.Sprintf("m-%d", i), Payload: "data"})
+	}
+
+	// Wait for all messages to be consumed.
+	assert.Eventually(t, func() bool {
+		return atomic.LoadInt64(&processedCount) == int64(n)
+	}, 8*time.Second, 100*time.Millisecond, "expected all %d messages to be processed", n)
+
+	// The hook must have fired exactly once per message.
+	assert.Equal(t, int64(n), atomic.LoadInt64(&grlCalls),
+		"global rate limiter should be called once per message, not once per batch")
+	// All call sites are consumers, so the flag is always false.
+	assert.Equal(t, int32(0), atomic.LoadInt32(&sawProducerFlag),
+		"producerOrConsumer should be false for consumer call sites")
+}
+
+// TestRedisPriorityConsumerGlobalRateLimiterPerMessage is the same contract
+// check for the priority consumer's worker loop.
+func TestRedisPriorityConsumerGlobalRateLimiterPerMessage(t *testing.T) {
+	if util.IsStringEmpty(redisEndpoint) {
+		redisEndpoint = "localhost:6379"
+	}
+
+	cf, _ := test.MockCf(t, zap.InfoLevel)
+	topic := fmt.Sprintf("test-grl-prio-%d", time.Now().UnixNano())
+	serviceName := "test-" + uuid.NewString()
+	consumerName := "grl-prio-cons"
+
+	producer, err := NewRedisProducer(cf, messaging.ProducerConfig{
+		Name: "p", Type: "redis", Topic: topic, Enabled: true,
+		Endpoint: redisEndpoint, MandatoryServiceName: serviceName,
+		Properties: map[string]interface{}{"priority_enabled": true},
+	})
+	if err != nil {
+		t.Skip("Redis not available")
+		return
+	}
+
+	consumer, err := NewRedisPriorityConsumer(cf, messaging.ConsumerConfig{
+		Name: consumerName, Type: "redis", Topic: topic, Enabled: true,
+		Endpoint: redisEndpoint, MandatoryServiceName: serviceName,
+		Properties: map[string]interface{}{"priority_enabled": true, "batch_size": 100},
+	})
+	assert.NoError(t, err)
+
+	var grlCalls int64
+	originalGRL := GlobalRateLimiter
+	GlobalRateLimiter = func(producerOrConsumer bool, name string) error {
+		if name == consumerName {
+			atomic.AddInt64(&grlCalls, 1)
+		}
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer func() {
+		cancel()
+		_ = consumer.Stop()
+		_ = producer.Stop()
+		time.Sleep(300 * time.Millisecond)
+		GlobalRateLimiter = originalGRL
+	}()
+
+	var processedCount int64
+	consumeFunc := &mockConsumeFunction{
+		processFunc: func(message *messaging.Message) error {
+			atomic.AddInt64(&processedCount, 1)
+			return nil
+		},
+	}
+
+	err = consumer.Process(ctx, consumeFunc)
+	assert.NoError(t, err)
+
+	const n = 5
+	for i := 0; i < n; i++ {
+		<-producer.Send(ctx, &messaging.Message{Key: fmt.Sprintf("m-%d", i), Payload: "data", Priority: i % 3})
+	}
+
+	assert.Eventually(t, func() bool {
+		return atomic.LoadInt64(&processedCount) == int64(n)
+	}, 8*time.Second, 100*time.Millisecond, "expected all %d messages to be processed", n)
+
+	assert.Equal(t, int64(n), atomic.LoadInt64(&grlCalls),
+		"global rate limiter should be called once per message, not once per batch")
+}


### PR DESCRIPTION
## Summary

The `GlobalRateLimiter` hook (added in `6f39cea`) was called **once per batch fetch** in the Redis consumers, at the top of the worker loop — before the batch was fetched and its size known. For a per-message throttle this is the wrong granularity: one fetch can return up to `batch_size` messages, and the hook also fired on empty/idle polls.

This PR moves the hook into the inner per-message loop (right next to `c.ratelimit.Take()`), so it fires **exactly once per consumed message** and never on empty or expired-job iterations. Applies to both `redis/consumer.go` and `redis/consumer_prio.go`. Kafka is unchanged (its loop is already one-message-per-iteration).

## Tests

Adds `redis/ratelimiter_test.go` covering both the standard and priority consumers:

- Overrides the package-level `GlobalRateLimiter` with a per-consumer-name counter, sends N messages, and asserts the hook fired **exactly N times**.
- Uses a large `batch_size` (100) on purpose so all messages arrive in a single fetch — under the old per-batch placement the count would be ~1, so this test is a genuine regression guard.
- Restores the global var in a fixed teardown order (cancel → Stop → settle → restore) since `Stop()` does not wait for the worker goroutine.

Verified against a live Redis: both tests pass on this branch, and the standard-consumer test **fails** when the hook is reverted to the old per-batch placement (`global rate limiter should be called once per message, not once per batch`).

> Note: the tests require a reachable Redis at `localhost:6379`, consistent with the rest of the `redis/` suite (they `t.Skip` otherwise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)